### PR TITLE
fix: stop leaking cleanup goroutines

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -44,47 +44,71 @@ func connectBluesky(ctx context.Context, handle, appKey string) (*bk.Client, err
 
 // RunWithReconnect attempts to run the bot with automatic reconnection on failure
 func RunWithReconnect(ctx context.Context, mc *minio.Client, cfg Config) error {
+	cacheClient := content.NewCacheClientS3(ctx, mc, cfg.CacheBucket)
+
+	cleanup := content.NewS3Cleanup(mc, cfg.CacheBucket)
+	cleanup.Start(ctx)
+	defer cleanup.Stop()
+
+	if err := content.Start(cfg.GitHubToken, cacheClient); err != nil {
+		return fmt.Errorf("failed to start service: %w", err)
+	}
+
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		client, err := connectBluesky(ctx, cfg.Handle, cfg.AppKey)
 		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			slog.Error("failed to connect to Bluesky", "error", err)
 			slog.Info("retrying connection", "delay", reconnectDelay)
-			time.Sleep(reconnectDelay)
-			continue
-		}
-
-		c := bluesky.Client{
-			Client: client,
-		}
-
-		cacheClient := content.NewCacheClientS3(ctx, mc, cfg.CacheBucket)
-
-		// Initialize and start the cleanup handler
-		cleanup := content.NewS3Cleanup(mc, cfg.CacheBucket)
-		cleanup.Start(ctx)
-		defer cleanup.Stop()
-
-		if err := content.Start(cfg.GitHubToken, cacheClient); err != nil {
-			slog.Error("failed to start service", "error", err)
-			client.Close()
-			time.Sleep(reconnectDelay)
-			continue
-		}
-
-		// Run the main loop
-		for {
-			slog.DebugContext(ctx, "checking...")
-			if err := content.Do(ctx, c); err != nil {
-				if !errors.Is(err, content.ErrCouldNotContent) {
-					slog.Error("error during content check", "error", err)
-					client.Close()
-					time.Sleep(reconnectDelay)
-					break
-				}
-				slog.DebugContext(ctx, "backing off...")
+			if err := sleepCtx(ctx, reconnectDelay); err != nil {
+				return err
 			}
-
-			time.Sleep(checkInterval)
+			continue
 		}
+
+		c := bluesky.Client{Client: client}
+		runSession(ctx, c)
+		client.Close()
+
+		if err := sleepCtx(ctx, reconnectDelay); err != nil {
+			return err
+		}
+	}
+}
+
+// runSession runs the inner check loop until ctx is cancelled or content.Do
+// returns a non-recoverable error. The caller is responsible for closing the
+// bluesky client and reconnecting.
+func runSession(ctx context.Context, c bluesky.Client) {
+	for {
+		slog.DebugContext(ctx, "checking...")
+		if err := content.Do(ctx, c); err != nil {
+			if !errors.Is(err, content.ErrCouldNotContent) {
+				slog.Error("error during content check", "error", err)
+				return
+			}
+			slog.DebugContext(ctx, "backing off...")
+		}
+		if err := sleepCtx(ctx, checkInterval); err != nil {
+			return
+		}
+	}
+}
+
+// sleepCtx sleeps for d, returning ctx.Err() if ctx is cancelled first.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
 	}
 }

--- a/internal/content/s3_cleanup.go
+++ b/internal/content/s3_cleanup.go
@@ -3,6 +3,7 @@ package content
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/minio/minio-go/v7"
@@ -17,6 +18,7 @@ type S3Cleanup struct {
 	cleanupInterval time.Duration
 	// stopCleanup is used to signal the cleanup routine to stop
 	stopCleanup chan struct{}
+	stopOnce    sync.Once
 }
 
 // NewS3Cleanup creates a new S3 cleanup handler
@@ -34,15 +36,21 @@ func (c *S3Cleanup) Start(ctx context.Context) {
 	go c.cleanupRoutine(ctx)
 }
 
-// Stop stops the background cleanup routine
+// Stop stops the background cleanup routine. Safe to call multiple times.
 func (c *S3Cleanup) Stop() {
-	close(c.stopCleanup)
+	c.stopOnce.Do(func() { close(c.stopCleanup) })
 }
 
-// cleanupRoutine periodically checks for and deletes expired objects
+// cleanupRoutine periodically checks for and deletes expired objects.
+// It runs once at startup before entering the ticker loop so restarts
+// shorter than cleanupInterval do not skip cleanup entirely.
 func (c *S3Cleanup) cleanupRoutine(ctx context.Context) {
 	ticker := time.NewTicker(c.cleanupInterval)
 	defer ticker.Stop()
+
+	if err := c.cleanupExpired(ctx); err != nil {
+		utils.LogErrorWithContext(ctx, fmt.Errorf("failed to cleanup expired objects: %w", err))
+	}
 
 	for {
 		select {
@@ -50,6 +58,8 @@ func (c *S3Cleanup) cleanupRoutine(ctx context.Context) {
 			if err := c.cleanupExpired(ctx); err != nil {
 				utils.LogErrorWithContext(ctx, fmt.Errorf("failed to cleanup expired objects: %w", err))
 			}
+		case <-ctx.Done():
+			return
 		case <-c.stopCleanup:
 			return
 		}


### PR DESCRIPTION
move the cache client and S3 cleanup setup out of the reconnect
loop in RunWithReconnect so the deferred cleanup.Stop() runs on
exit.

previously each reconnect spawned a new cleanup goroutine without
stopping the old ones, since the outer loop never returned.

replace bare time.Sleep calls with a ctx-aware sleepCtx helper so
SIGTERM aborts the reconnect backoff and inner check loop
immediately, instead of waiting up to 15 minutes.

extract the inner loop into runSession for clarity.

in s3_cleanup.go, guard Stop() with sync.Once so a double-close
cannot panic, and have the routine select on ctx.Done() in
addition to its stop channel.

run cleanupExpired once at startup before entering the 24h ticker
— restarts shorter than the cleanup interval previously skipped
cleanup entirely.
