### PR TITLE
chore(config): rename the "github-token" env variable

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -63,7 +63,7 @@ func main() {
 			},
 			&cli.StringFlag{
 				Name:     "github-token",
-				Sources:  cli.EnvVars("GITHUB_TOKEN"),
+				Sources:  cli.EnvVars("GH_TOKEN"),
 				Required: true,
 			},
 		},


### PR DESCRIPTION
`GITHUB_TOKEN` is frequently used by tools such as `gh`, so the
limited pat for this bot always conflicts.
