### PR TITLE
fix: search

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
+	github.com/google/go-github/v39 v39.2.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tailscale/go-bluesky v0.0.0-20241115170709-693553a07285
 	github.com/urfave/cli/v3 v3.8.0
@@ -20,7 +21,6 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/go-github/v39 v39.2.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -27,7 +27,9 @@ func Start(token string, cacheClient cache.Client) error {
 		Language: "go",
 	}
 
-	provider = github.NewProvider(token, cfg, cacheClient)
+	p := github.NewProvider(token, cfg, cacheClient)
+	p.GithubSearchClient = larrySearchFix{inner: p.GithubSearchClient}
+	provider = p
 	return nil
 }
 

--- a/internal/content/larry_fix.go
+++ b/internal/content/larry_fix.go
@@ -1,0 +1,27 @@
+package content
+
+import (
+	"context"
+	"strings"
+
+	gh "github.com/google/go-github/v39/github"
+)
+
+// larrySearchFix wraps larry's GitHub search client to repair a query-encoding
+// bug in upstream (which is unmaintained).
+//
+// larry joins qualifiers with literal '+' characters (e.g. "a+language:go").
+// go-github URL-encodes those as %2B, so GitHub receives a single fuzzy text
+// term and silently drops the language qualifier — returning repos in any language.
+//
+// Spaces, which go-github encodes as '+' on the wire, are the actual GitHub search
+// separator.
+type larrySearchFix struct {
+	inner interface {
+		Repositories(ctx context.Context, query string, opt *gh.SearchOptions) (*gh.RepositoriesSearchResult, *gh.Response, error)
+	}
+}
+
+func (f larrySearchFix) Repositories(ctx context.Context, query string, opt *gh.SearchOptions) (*gh.RepositoriesSearchResult, *gh.Response, error) {
+	return f.inner.Repositories(ctx, strings.ReplaceAll(query, "+", " "), opt)
+}


### PR DESCRIPTION
removes the "+" from searches which causes a faulty encoding and
then makes the GitHub Search API drop the `language:go`.

related: ezeoleaf/larry#155
